### PR TITLE
[Cycode] Fix for IaC misconfiguration - Ensure that Service Account Tokens are only mounted where necessary

### DIFF
--- a/weavesock-fixed/deploy/kubernetes/manifests/user-db-dep.yaml
+++ b/weavesock-fixed/deploy/kubernetes/manifests/user-db-dep.yaml
@@ -38,3 +38,4 @@ spec:
             medium: Memory
       nodeSelector:
         beta.kubernetes.io/os: linux
+      automountServiceAccountToken: false


### PR DESCRIPTION
[Cycode] Fix for IaC misconfiguration - Ensure that Service Account Tokens are only mounted where necessary