### PR TITLE
[Cycode] Fix for IaC misconfiguration - Ensure that Service Account Tokens are only mounted where necessary

### DIFF
--- a/weavesock-fixed/deploy/kubernetes/manifests/rabbitmq-dep.yaml
+++ b/weavesock-fixed/deploy/kubernetes/manifests/rabbitmq-dep.yaml
@@ -40,3 +40,4 @@ spec:
           name: exporter
       nodeSelector:
         beta.kubernetes.io/os: linux
+      automountServiceAccountToken: false


### PR DESCRIPTION
[Cycode] Fix for IaC misconfiguration - Ensure that Service Account Tokens are only mounted where necessary