### PR TITLE
[Cycode] Fix for IaC misconfiguration - Ensure that Service Account Tokens are only mounted where necessary

### DIFF
--- a/weavesock-fixed/deploy/kubernetes/manifests/shipping-dep.yaml
+++ b/weavesock-fixed/deploy/kubernetes/manifests/shipping-dep.yaml
@@ -60,3 +60,4 @@ spec:
             medium: Memory
       nodeSelector:
         beta.kubernetes.io/os: linux
+      automountServiceAccountToken: false


### PR DESCRIPTION
[Cycode] Fix for IaC misconfiguration - Ensure that Service Account Tokens are only mounted where necessary