### PR TITLE
[Cycode] Fix for IaC misconfiguration - Ensure that Service Account Tokens are only mounted where necessary

### DIFF
--- a/weavesock-fixed/deploy/kubernetes/manifests/queue-master-dep.yaml
+++ b/weavesock-fixed/deploy/kubernetes/manifests/queue-master-dep.yaml
@@ -44,3 +44,4 @@ spec:
           periodSeconds: 3
       nodeSelector:
         beta.kubernetes.io/os: linux
+      automountServiceAccountToken: false


### PR DESCRIPTION
[Cycode] Fix for IaC misconfiguration - Ensure that Service Account Tokens are only mounted where necessary